### PR TITLE
Use jQuery on instead of javascript onunload

### DIFF
--- a/src/Helios-Core.js
+++ b/src/Helios-Core.js
@@ -5451,7 +5451,7 @@ var self=this;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx1) {
 //>>excludeEnd("ctx");
-$recv(parent)._onunload_((function(){
+$recv(parent)._at_put_("onunload",(function(){
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx2) {
 //>>excludeEnd("ctx");
@@ -5468,10 +5468,10 @@ return self;
 },
 //>>excludeStart("ide", pragmas.excludeIdeData);
 args: ["parent"],
-source: "handleLossOfEnvironmentWithParent: parent\x0a\x09parent onunload: [ \x0a\x09\x09self removeBeforeUnloadMessage.\x0a\x09\x09window close ]",
+source: "handleLossOfEnvironmentWithParent: parent\x0a\x09parent at: 'onunload' put: [ \x0a\x09\x09self removeBeforeUnloadMessage.\x0a\x09\x09window close ]",
 referencedClasses: [],
 //>>excludeEnd("ide");
-messageSends: ["onunload:", "removeBeforeUnloadMessage", "close"]
+messageSends: ["at:put:", "removeBeforeUnloadMessage", "close"]
 }),
 $globals.HLManager);
 

--- a/src/Helios-Core.st
+++ b/src/Helios-Core.st
@@ -1278,7 +1278,7 @@ confirm: aString ifTrue: aBlock ifFalse: anotherBlock
 !
 
 handleLossOfEnvironmentWithParent: parent
-	parent onunload: [ 
+	parent at: 'onunload' put: [ 
 		self removeBeforeUnloadMessage.
 		window close ]
 !


### PR DESCRIPTION
@herby, sorry I found a bug on my previous commit.

If you popup Helios, then close it and popup Helios a second time it will not close on the parent unload event.
It appears calling onunload: multiple times does not work.

I have changed it to rather use jQuery on: do: and can confirm that the bug is no longer present.