### PR TITLE
add compilation of helios.less to Gruntfile + grunt watch task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,9 +16,10 @@ module.exports = function(grunt) {
   var path = require('path');
 
   // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('grunt-execute');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-execute');
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('amber-dev');
 
   // Default task.
@@ -90,6 +91,16 @@ module.exports = function(grunt) {
 
     clean: {
       test_runner: ['test_runner.js']
+    },
+
+    watch: {
+      less: {
+        files: ['resources/*.less'],
+        tasks: ['less'],
+        options: {
+          spawn: false
+        }
+      }
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,11 +17,12 @@ module.exports = function(grunt) {
 
   // These plugins provide necessary tasks.
   grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-execute');
   grunt.loadNpmTasks('amber-dev');
 
   // Default task.
-  grunt.registerTask('default', ['amberc:all']);
+  grunt.registerTask('default', ['less', 'amberc:all']);
   grunt.registerTask('test', ['amberc:test_runner', 'execute:test_runner', 'clean:test_runner']);
   grunt.registerTask('devel', ['amdconfig:helios']);
 
@@ -35,11 +36,18 @@ module.exports = function(grunt) {
       '* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;' +
       ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */\n',
     // task configuration
+    less: {
+      development: {
+        files: {
+          'resources/helios.css': 'resources/helios.less'
+        }
+      }
+    },
+
     amberc: {
       options: {
         amber_dir: findAmberPath(['../..', 'bower_components/amber']),
         library_dirs: ['src'],
-        closure_jar: ''
       },
       all: {
         output_dir : 'src',

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-less": "^1.0.1",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-execute": "^0.2.1",
     "requirejs": "^2.1.15"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   },
   "devDependencies": {
     "amber-dev": "^0.4.0",
-    "grunt": "^0.4.0",
+    "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-less": "^1.0.1",
     "grunt-execute": "^0.2.1",
     "requirejs": "^2.1.15"
   },


### PR DESCRIPTION
Gruntfile now contains a task to compile .less to .css files (requires Grunt 0.4.5).
In addition, a watch task is added to automatically do this step upon changes to helios.less (fix #40).

Please merge this after #61 has been merged.